### PR TITLE
Opportunity to select the protocol in a Address

### DIFF
--- a/msgpackrpc/address.py
+++ b/msgpackrpc/address.py
@@ -8,9 +8,10 @@ class Address(object):
     The class to represent the RPC address.
     """
 
-    def __init__(self, host, port):
+    def __init__(self, host, port, family=socket.AF_UNSPEC):
         self._host = host
         self._port = port
+        self._family = family
 
     @property
     def host(self):
@@ -23,8 +24,8 @@ class Address(object):
     def unpack(self):
         return (self._host, self._port)
 
-    def socket(self, family=socket.AF_UNSPEC):
-        res = socket.getaddrinfo(self._host, self._port, family,
+    def socket(self):
+        res = socket.getaddrinfo(self._host, self._port, self._family,
                                  socket.SOCK_STREAM, 0, socket.AI_PASSIVE)[0]
         af, socktype, proto, canonname, sockaddr = res
         sock = socket.socket(af, socktype, proto)


### PR DESCRIPTION
Hi.

You do not give for client code ability to change the attribute 'family' on method 'socket' of class 'Address'.

The method:
``` python
class Address(object):
  ...
    def socket(self, family=socket.AF_UNSPEC):
        res = socket.getaddrinfo(self._host, self._port, family,
                                 socket.SOCK_STREAM, 0, socket.AI_PASSIVE)[0]
        af, socktype, proto, canonname, sockaddr = res
        sock = socket.socket(af, socktype, proto)
        set_close_exec(sock.fileno())
        sock.setblocking(0)
        if af == socket.AF_INET6:
            if hasattr(socket, "IPPROTO_IPV6"):
                sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 1)

        return sock
```

And his single use:
``` python
class ClientTransport(object):
 ...
    def connect(self):
        stream = IOStream(self._address.socket(), io_loop=self._session._loop._ioloop)  # <-- here
        socket = ClientSocket(stream, self, self._encodings)
        socket.connect();
```


I have not found to influence the choice of protocol (AF_INET, AF_INET6).
This can be a nuisance when the client connects to 'localhost' or another hostname where ipv6 is used.
By default, 'Client' will be use ipv6, although it is likely the 'Server' listening ipv4.
Additional Information:
  http://askubuntu.com/questions/32298/prefer-a-ipv4-dns-lookups-before-aaaaipv6-lookups

And your commit:
```
commit 886b26e18a5aca504c3ac8379095defaf90d5598
Author: Ken Sato <ksato9700@gmail.com>
Date:   Mon Nov 28 23:36:17 2011 -0800

    Found I'm getting IPv6 address for localhost.
    
    How can I bind both IPv4 and v6 address in the server side?
```

Maybe you could provide the choice of protocol in 'Address' class?
