### PR TITLE
add closing protection for Session

### DIFF
--- a/msgpackrpc/error.py
+++ b/msgpackrpc/error.py
@@ -23,6 +23,10 @@ class TransportError(RPCError):
     CODE = ".TransportError"
     pass
 
+class SessionError(RPCError):
+    CODE = ".SessionError"
+    pass
+
 class CallError(RPCError):
     CODE = ".NoMethodError"
     pass


### PR DESCRIPTION
when `Session.on_connect_failed` was called, if other request come in, the `Session._request_table` will be raise RuntimeError('dictionay be changed')