### PR TITLE
Change msgpack-python to msgpack

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ MessagePack RPC for Python.
 This implementation uses Tornado framework as a backend.
 """,
       packages=['msgpackrpc', 'msgpackrpc/transport'],
-      install_requires=['msgpack-python', 'tornado >= 3,<5'],
+      install_requires=['msgpack', 'tornado >= 3,<5'],
       license="Apache Software License",
       classifiers=[
           'Programming Language :: Python :: 2',


### PR DESCRIPTION
Change msgpack dependency.

msgpack-python is deprecated.
Alternative package is msgpack.

https://pypi.org/project/msgpack-python/