### PR TITLE
Replace deprecated msgpack-python with msgpack + python3 compatibility

### DIFF
--- a/example/echoserver.py
+++ b/example/echoserver.py
@@ -29,19 +29,18 @@ def serve(daemon=False):
 
     To stop, use ``server.shutdown()``
     """
-    for port in xrange(9000, 10000):
+    for port in range(9000, 10000):
         try:
             addr = msgpackrpc.Address('localhost', port)
             server = msgpackrpc.Server(EchoHandler())
-            print server
+            print(server)
             server.listen(addr)
             thread = serve_background(server, daemon)
-            return (addr, server, thread)
+            return addr, server, thread
         except Exception as err:
-            print err
+            print(err)
             pass
 
 if __name__ == '__main__':
-    port = serve(False)
-    print "Serving on localhost:%d\n" % port[1]
-
+    addr, server, thread = serve(False)
+    print("Serving on %s:%d\n" % (addr._host, addr._port))

--- a/example/test_client.py
+++ b/example/test_client.py
@@ -20,7 +20,7 @@ def teardown():
 
 def test_client():
     global ADDR
-    client = msgpackrpc.Client(ADDR, unpack_encoding = 'utf-8')
+    client = msgpackrpc.Client(ADDR)
 
     f1 = client.call('echo', 'foo')
     f2 = client.call('echo', 'bar')
@@ -30,7 +30,7 @@ def test_client():
     assert f1 == 'foo'
     assert f3 == 'baz'
 
-    print "EchoHandler#echo via msgpackrpc"
+    print("EchoHandler#echo via msgpackrpc")
 
 
 if __name__ == '__main__':

--- a/msgpackrpc/client.py
+++ b/msgpackrpc/client.py
@@ -7,9 +7,9 @@ class Client(session.Session):
     Client is useful for MessagePack RPC API.
     """
 
-    def __init__(self, address, timeout=10, loop=None, builder=tcp, reconnect_limit=5, pack_encoding='utf-8', unpack_encoding=None):
+    def __init__(self, address, timeout=10, loop=None, builder=tcp, reconnect_limit=5):
         loop = loop or Loop()
-        session.Session.__init__(self, address, timeout, loop, builder, reconnect_limit, pack_encoding, unpack_encoding)
+        session.Session.__init__(self, address, timeout, loop, builder, reconnect_limit)
 
         if timeout:
             loop.attach_periodic_callback(self.step_timeout, 1000) # each 1s

--- a/msgpackrpc/server.py
+++ b/msgpackrpc/server.py
@@ -12,15 +12,14 @@ class Server(session.Session):
     Server is usaful for MessagePack RPC Server.
     """
 
-    def __init__(self, dispatcher, loop=None, builder=tcp, pack_encoding='utf-8', unpack_encoding=None):
+    def __init__(self, dispatcher, loop=None, builder=tcp):
         self._loop = loop or Loop()
         self._builder = builder
-        self._encodings = (pack_encoding, unpack_encoding)
         self._listeners = []
         self._dispatcher = dispatcher
 
     def listen(self, address):
-        listener = self._builder.ServerTransport(address, self._encodings)
+        listener = self._builder.ServerTransport(address)
         listener.listen(self)
         self._listeners.append(listener)
 

--- a/msgpackrpc/session.py
+++ b/msgpackrpc/session.py
@@ -19,7 +19,7 @@ class Session(object):
     result to the corresponding future.
     """
 
-    def __init__(self, address, timeout, loop=None, builder=tcp, reconnect_limit=5, pack_encoding='utf-8', unpack_encoding=None):
+    def __init__(self, address, timeout, loop=None, builder=tcp, reconnect_limit=5):
         """\
         :param address: address of the server.
         :param loop:    context object.
@@ -29,7 +29,7 @@ class Session(object):
         self._loop = loop or Loop()
         self._address = address
         self._timeout = timeout
-        self._transport = builder.ClientTransport(self, self._address, reconnect_limit, encodings=(pack_encoding, unpack_encoding))
+        self._transport = builder.ClientTransport(self, self._address, reconnect_limit)
         self._generator = _NoSyncIDGenerator()
         self._request_table = {}
 

--- a/msgpackrpc/transport/tcp.py
+++ b/msgpackrpc/transport/tcp.py
@@ -7,10 +7,10 @@ from msgpackrpc.error import RPCError, TransportError
 
 
 class BaseSocket(object):
-    def __init__(self, stream, encodings):
+    def __init__(self, stream):
         self._stream = stream
-        self._packer = msgpack.Packer(encoding=encodings[0], default=lambda x: x.to_msgpack())
-        self._unpacker = msgpack.Unpacker(encoding=encodings[1])
+        self._packer = msgpack.Packer(default=lambda x: x.to_msgpack())
+        self._unpacker = msgpack.Unpacker()
 
     def close(self):
         self._stream.close()
@@ -49,8 +49,8 @@ class BaseSocket(object):
 
 
 class ClientSocket(BaseSocket):
-    def __init__(self, stream, transport, encodings):
-        BaseSocket.__init__(self, stream, encodings)
+    def __init__(self, stream, transport):
+        BaseSocket.__init__(self, stream)
         self._transport = transport
         self._stream.set_close_callback(self.on_close)
 
@@ -72,10 +72,9 @@ class ClientSocket(BaseSocket):
 
 
 class ClientTransport(object):
-    def __init__(self, session, address, reconnect_limit, encodings=('utf-8', None)):
+    def __init__(self, session, address, reconnect_limit):
         self._session = session
         self._address = address
-        self._encodings = encodings
         self._reconnect_limit = reconnect_limit;
 
         self._connecting = 0
@@ -95,7 +94,7 @@ class ClientTransport(object):
 
     def connect(self):
         stream = IOStream(self._address.socket(), io_loop=self._session._loop._ioloop)
-        socket = ClientSocket(stream, self, self._encodings)
+        socket = ClientSocket(stream, self)
         socket.connect();
 
     def close(self):
@@ -135,8 +134,8 @@ class ClientTransport(object):
 
 
 class ServerSocket(BaseSocket):
-    def __init__(self, stream, transport, encodings):
-        BaseSocket.__init__(self, stream, encodings)
+    def __init__(self, stream, transport):
+        BaseSocket.__init__(self, stream)
         self._transport = transport
         self._stream.read_until_close(self.on_read, self.on_read)
 
@@ -151,23 +150,21 @@ class ServerSocket(BaseSocket):
 
 
 class MessagePackServer(tcpserver.TCPServer):
-    def __init__(self, transport, io_loop=None, encodings=None):
+    def __init__(self, transport, io_loop=None):
         self._transport = transport
-        self._encodings = encodings
         tcpserver.TCPServer.__init__(self, io_loop=io_loop)
 
     def handle_stream(self, stream, address):
-        ServerSocket(stream, self._transport, self._encodings)
+        ServerSocket(stream, self._transport)
 
 
 class ServerTransport(object):
-    def __init__(self, address, encodings=('utf-8', None)):
+    def __init__(self, address):
         self._address = address;
-        self._encodings = encodings
 
     def listen(self, server):
         self._server = server;
-        self._mp_server = MessagePackServer(self, io_loop=self._server._loop._ioloop, encodings=self._encodings)
+        self._mp_server = MessagePackServer(self, io_loop=self._server._loop._ioloop)
         self._mp_server.listen(self._address.port)
 
     def close(self):

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ MessagePack RPC for Python.
 This implementation uses Tornado framework as a backend.
 """,
       packages=['msgpackrpc', 'msgpackrpc/transport'],
-      install_requires=['msgpack-python', 'tornado >= 3,<5'],
+      install_requires=['msgpack >= 1.0.0', 'tornado >= 3,<5'],
       license="Apache Software License",
       classifiers=[
           'Programming Language :: Python :: 2',

--- a/test/test_msgpackrpc.py
+++ b/test/test_msgpackrpc.py
@@ -87,7 +87,7 @@ class TestMessagePackRPC(unittest.TestCase):
         lock.acquire()
         lock.acquire()   # wait for the server to start
 
-        self._client = msgpackrpc.Client(self._address, unpack_encoding='utf-8')
+        self._client = msgpackrpc.Client(self._address)
         return self._client;
 
     def tearDown(self):
@@ -169,7 +169,7 @@ class TestMessagePackRPC(unittest.TestCase):
     def test_connect_failed(self):
         client = self.setup_env();
         port = helper.unused_port()
-        client = msgpackrpc.Client(msgpackrpc.Address('localhost', port), unpack_encoding='utf-8')
+        client = msgpackrpc.Client(msgpackrpc.Address('localhost', port))
         self.assertRaises(error.TransportError, lambda: client.call('hello'))
 
     def test_timeout(self):
@@ -178,7 +178,7 @@ class TestMessagePackRPC(unittest.TestCase):
         if self.__class__.ENABLE_TIMEOUT_TEST:
             self.assertEqual(client.call('long_exec'), 'finish!', "'long_exec' result is incorrect")
 
-            client = msgpackrpc.Client(self._address, timeout=1, unpack_encoding='utf-8')
+            client = msgpackrpc.Client(self._address, timeout=1)
             self.assertRaises(error.TimeoutError, lambda: client.call('long_exec'))
         else:
             print("Skip test_timeout")


### PR DESCRIPTION
Hi @repeatedly!

I really like this lib, and I have found no equivalent of it: it is both very easy to use and very fast (the fastest Python lib I know of).
Sadly, there is one point that make it unusable for us: it depends on `msgpack-python`, which is deprecated, and incompatible with the new `msgpack` (which we use in the same code).

So I tried #22 (only replacing the package name in requirements), but it does not work, because the `encoding` parameter has been removed from `Packer` and `Unpacker` in `msgpack==1.0.0` (since it now uses UTF-8 by default).

Hence this pull request, which ensures compatibility with `msgpack` 1.0.0 (tested only with python 3.6). I simply removed everything related to encodings.

Thanks!