### PR TITLE
docs: Fix a few typos

### DIFF
--- a/msgpackrpc/server.py
+++ b/msgpackrpc/server.py
@@ -9,7 +9,7 @@ from msgpackrpc.transport import tcp
 
 class Server(session.Session):
     """\
-    Server is usaful for MessagePack RPC Server.
+    Server is useful for MessagePack RPC Server.
     """
 
     def __init__(self, dispatcher, loop=None, builder=tcp, pack_encoding='utf-8', unpack_encoding=None):

--- a/msgpackrpc/session.py
+++ b/msgpackrpc/session.py
@@ -12,7 +12,7 @@ class Session(object):
     transport layer.
 
     self._request_table(request table) stores the relationship between messageid and
-    corresponding future. When the new requets are sent, the Session generates
+    corresponding future. When the new request are sent, the Session generates
     new message id and new future. Then the Session registers them to request table.
 
     When it receives the message, the Session lookups the request table and set the


### PR DESCRIPTION
There are small typos in:
- msgpackrpc/server.py
- msgpackrpc/session.py

Fixes:
- Should read `useful` rather than `usaful`.
- Should read `request` rather than `requets`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md